### PR TITLE
Add local candidate-sentence similarity scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ This is an adaptation of the original MDERank model, specifically optimized for 
 Original Paper: MDERank: A Masked Document Embedding Rank Approach for Unsupervised Keyphrase Extraction
 Original Repo: https://github.com/LinhanZ/mderank
 
+## English Enhancements
+
+The English variant now defaults to **SciBERT**, augments the global masking
+score with a local candidate–sentence similarity signal, and adds a
+title-driven theme score that rewards phrases aligned with the document's main
+topic.
+
 ## Features
 
 - Optimized for Indonesian language processing


### PR DESCRIPTION
## Summary
- Track sentence indices for each candidate phrase during extraction
- Rank candidates by combining global masking scores with local sentence similarity
- Incorporate title-driven theme vectors to reward phrases aligned with document topics
- Document new theme-based scoring in README

## Testing
- `python -m py_compile MDERank/mderank_main.py`


------
https://chatgpt.com/codex/tasks/task_e_6897456fe110832abb1acedc872e07aa